### PR TITLE
Issue: #39 JmsReceiver now supports passing AcknowledgeMode as a parameter

### DIFF
--- a/src/main/scala/ru/reajames/Jms.scala
+++ b/src/main/scala/ru/reajames/Jms.scala
@@ -57,15 +57,8 @@ object Jms {
     * @param acknowledgeMode specifies acknowledge mode or if the session is transaction aware
     * @return created session or failure
     */
-  def session(connection: Connection, acknowledgeMode: Int = Session.AUTO_ACKNOWLEDGE): Try[Session] = {
-    Try(acknowledgeMode match {
-      case Session.SESSION_TRANSACTED =>
-        connection.createSession(true, acknowledgeMode)
-      case _ =>
-        connection.createSession(false, acknowledgeMode)
-    })
-  }
-
+  def session(connection: Connection, acknowledgeMode: Int = Session.AUTO_ACKNOWLEDGE): Try[Session] =
+    Try(connection.createSession(acknowledgeMode == Session.SESSION_TRANSACTED, acknowledgeMode))
 
   /**
     * Creates a destination by the specified destination factory.

--- a/src/main/scala/ru/reajames/Jms.scala
+++ b/src/main/scala/ru/reajames/Jms.scala
@@ -54,13 +54,17 @@ object Jms {
   /**
     * Creates a session by the specified connection.
     * @param connection specifies connection to create a session
-    * @param transacted specifies whether created session is transaction aware or not
-    * @param acknowledgeMode specifies acknowledge mode
+    * @param acknowledgeMode specifies acknowledge mode or if the session is transaction aware
     * @return created session or failure
     */
-  def session(connection: Connection, transacted: Boolean = false,
-              acknowledgeMode: Int = Session.AUTO_ACKNOWLEDGE): Try[Session] =
-    Try(connection.createSession(transacted, acknowledgeMode))
+  def session(connection: Connection, acknowledgeMode: Int = Session.AUTO_ACKNOWLEDGE): Try[Session] = {
+    Try(acknowledgeMode match {
+      case Session.SESSION_TRANSACTED =>
+        connection.createSession(true, acknowledgeMode)
+      case _ =>
+        connection.createSession(false, acknowledgeMode)
+    })
+  }
 
 
   /**

--- a/src/main/scala/ru/reajames/JmsReceiver.scala
+++ b/src/main/scala/ru/reajames/JmsReceiver.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
   * @param destinationFactory specifies source of messages
   * @param executionContext executes receiving messages
   */
-class JmsReceiver(connectionHolder: ConnectionHolder, destinationFactory: DestinationFactory)
+class JmsReceiver(connectionHolder: ConnectionHolder, destinationFactory: DestinationFactory, acknowledgeMode: Int = Session.AUTO_ACKNOWLEDGE)
                  (implicit executionContext: ExecutionContext) extends Publisher[Message] with Logging {
   require(connectionHolder != null, "Connection holder should be supplied!")
   require(destinationFactory != null, "Destination factory should be supplied!")
@@ -29,7 +29,7 @@ class JmsReceiver(connectionHolder: ConnectionHolder, destinationFactory: Destin
     Future {
       val subscription = for {
         c <- connectionHolder.connection
-        s <- session(c)
+        s <- session(c, acknowledgeMode)
         d <- destination(s, destinationFactory)
         consumer <- consumer(s, d)
       }

--- a/src/test/scala/ru/reajames/JavaFactoriesTest.java
+++ b/src/test/scala/ru/reajames/JavaFactoriesTest.java
@@ -58,7 +58,7 @@ public class JavaFactoriesTest extends TestNGSuite {
         });
 
         Connection c = connectionHolder.connection().get();
-        Session s = session(c, false, 1).get();
+        Session s = session(c, 1).get();
         MessageProducer p = producer(s, q.apply(s)).get();
         for (int i = 1; i <= 5; i++)
             send(p, textMessage(s, "" + i));
@@ -74,7 +74,7 @@ public class JavaFactoriesTest extends TestNGSuite {
         JmsSender<String> sender = createSender(connectionHolder, q, JavaFactories::textMessage, executor);
 
         Connection c = connectionHolder.connection().get();
-        Session s = session(c, false, 1).get();
+        Session s = session(c, 1).get();
         MessageConsumer cons = consumer(s, q.apply(s)).get();
 
         new Publisher<String>() {


### PR DESCRIPTION
Reference: #39

Changed Jms.session to only take acknowledgeMode, since it contains all the information needed.

You can only have transacted as true, if the acknowledge mode is 0,

and you can only use other acknowledge modes as long as transacted is false.

Therefore it is redundant to offer both parameters.

I've set a default value of AUTO_ACKNOWLEDGE, to keep consistent with previous versions and the spec in general.